### PR TITLE
Use unless instead of if

### DIFF
--- a/lib/capistrano/tasks/cachetool.rake
+++ b/lib/capistrano/tasks/cachetool.rake
@@ -11,7 +11,7 @@ namespace :cachetool do
   task :install_executable do
     on release_roles(fetch(:cachetool_roles)) do
       within shared_path do
-        if test '[', '!', '-e', 'cachetool.phar', ']'
+        unless test '[', '-e', 'cachetool.phar', ']'
           execute :curl, '-sO', fetch(:cachetool_download_url)
           execute :chmod, '+x', 'cachetool.phar'
         end


### PR DESCRIPTION
The if will fail and won't execute the actual install. With unless the tool is (re)installed if the command is not available